### PR TITLE
Resolve conflict in python-repl for windows

### DIFF
--- a/src/InlineAgent/pyproject.toml
+++ b/src/InlineAgent/pyproject.toml
@@ -23,8 +23,8 @@ dependencies = [
   "botocore == 1.37.23",
   "mcp == 1.6.0",
   # Data handling and analysis
-  "pandas >= 2.0.0",
-  "numpy >= 1.24.0",
+  "pandas == 2.2.2",
+  "numpy == 1.26.4",
   "yfinance >= 0.2.36",
   "fredapi >= 0.5.1",  # Federal Reserve Economic Data API
   # Visualization


### PR DESCRIPTION
Resolves the issue of `install_package` tool hanging for packages using pandas or numpy in python-repl MCP server.